### PR TITLE
Add -theme suffix to Zed extension ID

### DIFF
--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,6 +1,6 @@
-id = "tech49"
+id = "tech49-theme"
 name = "Tech49"
-version = "0.2.1"
+version = "0.2.2"
 schema_version = 1
 authors = ["Tim Dang"]
 description = "Dark color theme inspired by the movie Oblivion."

--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "tech49-theme"
-name = "Tech49"
-version = "0.2.2"
+name = "Tech49 Theme"
+version = "0.2.3"
 schema_version = 1
 authors = ["Tim Dang"]
 description = "Dark color theme inspired by the movie Oblivion."


### PR DESCRIPTION
Zed's [publishing prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites) require theme extension IDs to end in `-theme`. Renames the extension ID from `tech49` to `tech49-theme` and bumps to 0.2.2.

Requested by a Zed maintainer on the registry PR (zed-industries/extensions#6500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)